### PR TITLE
Fix iOS link for Valora

### DIFF
--- a/packages/rainbowkit-celo/wallets/valora.ts
+++ b/packages/rainbowkit-celo/wallets/valora.ts
@@ -3,6 +3,13 @@ import { getWalletConnectConnector } from "@rainbow-me/rainbowkit";
 
 import { Alfajores, Baklava, Celo } from "../chains";
 
+// rainbowkit utils has it but doesn't export it :/
+export function isAndroid(): boolean {
+  return (
+    typeof navigator !== "undefined" && /android/i.test(navigator.userAgent)
+  );
+}
+
 export interface ValoraOptions {
   chains: Chain[];
 }
@@ -25,8 +32,10 @@ export const Valora = ({
       chains,
     });
     async function getUri() {
-      const provider = await connector.getProvider()
-      return provider.connector.uri
+      const { uri } = (await connector.getProvider()).connector;
+      return isAndroid()
+        ? uri
+        : `https://valoraapp.com/wc?uri=${encodeURIComponent(uri)}`;
     }
     return {
       connector,

--- a/packages/rainbowkit-celo/wallets/valora.ts
+++ b/packages/rainbowkit-celo/wallets/valora.ts
@@ -35,7 +35,8 @@ export const Valora = ({
       const { uri } = (await connector.getProvider()).connector;
       return isAndroid()
         ? uri
-        : `https://valoraapp.com/wc?uri=${encodeURIComponent(uri)}`;
+        : // ideally this would use the WalletConnect registry, but this will do for now
+          `https://valoraapp.com/wc?uri=${encodeURIComponent(uri)}`;
     }
     return {
       connector,

--- a/packages/rainbowkit-celo/wallets/valora.ts
+++ b/packages/rainbowkit-celo/wallets/valora.ts
@@ -4,7 +4,7 @@ import { getWalletConnectConnector } from "@rainbow-me/rainbowkit";
 import { Alfajores, Baklava, Celo } from "../chains";
 
 // rainbowkit utils has it but doesn't export it :/
-export function isAndroid(): boolean {
+function isAndroid(): boolean {
   return (
     typeof navigator !== "undefined" && /android/i.test(navigator.userAgent)
   );


### PR DESCRIPTION
Tapping Valora on iOS would ask to open "Rainbow" (when installed, see video) or fail to open when not installed.

https://user-images.githubusercontent.com/57791/195844381-e1960f07-81c2-4249-80e7-9d47ac04ffcd.mp4

The universal link needs to be used on iOS.
This is what [WalletConnect does by default on iOS too](https://github.com/WalletConnect/walletconnect-monorepo/blob/v1.0/packages/helpers/browser-utils/src/mobile.ts#L7-L14).

Or [other wallets in RainbowKit](https://github.com/rainbow-me/rainbowkit/blob/b2284ff5a6387941297ffed6d597e2ea573332d3/packages/rainbowkit/src/wallets/walletConnectors/omniWallet/omniWallet.ts#L28-L32).  