### PR TITLE
Fix Valora QR code on desktop

### DIFF
--- a/packages/rainbowkit-celo/wallets/valora.ts
+++ b/packages/rainbowkit-celo/wallets/valora.ts
@@ -31,20 +31,19 @@ export const Valora = ({
     const connector = getWalletConnectConnector({
       chains,
     });
-    async function getUri() {
-      const { uri } = (await connector.getProvider()).connector;
-      return isAndroid()
-        ? uri
-        : // ideally this would use the WalletConnect registry, but this will do for now
-          `https://valoraapp.com/wc?uri=${encodeURIComponent(uri)}`;
-    }
     return {
       connector,
       mobile: {
-        getUri,
+        getUri: async () => {
+          const { uri } = (await connector.getProvider()).connector;
+          return isAndroid()
+            ? uri
+            : // ideally this would use the WalletConnect registry, but this will do for now
+              `https://valoraapp.com/wc?uri=${encodeURIComponent(uri)}`;
+        },
       },
       qrCode: {
-        getUri,
+        getUri: async () => (await connector.getProvider()).connector.uri,
         instructions: {
           learnMoreUrl: "https://valoraapp.com/learn",
           steps: [


### PR DESCRIPTION
Something I missed in https://github.com/celo-org/rainbowkit-celo/pull/6
The QR code should always use the `wc:` link. 
Otherwise Valora users scanning it get `qr code read failed: wallet address invalid`.