### PR TITLE
add multicall support

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@celo/rainbowkit-celo": "0.2.2",
+    "@celo/rainbowkit-celo": "0.3.0",
     "@mdx-js/loader": "^2.1.3",
     "@mdx-js/react": "^2.1.3",
     "@next/mdx": "^12.3.1",

--- a/packages/rainbowkit-celo/chains/alfajores.ts
+++ b/packages/rainbowkit-celo/chains/alfajores.ts
@@ -18,6 +18,10 @@ const Alfajores: Chain = {
     default: { name: 'Celo Explorer', url: 'https://explorer.celo.org/alfajores' },
     etherscan: { name: 'CeloScan', url: 'https://alfajores.celoscan.io/' },
   },
+  multicall: {
+    address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+    blockCreated: 14569001
+  },
   testnet: true,
 };
 

--- a/packages/rainbowkit-celo/chains/baklava.ts
+++ b/packages/rainbowkit-celo/chains/baklava.ts
@@ -18,6 +18,10 @@ const Baklava: Chain = {
     default: { name: 'Celo Explorer', url: 'https://explorer.celo.org/baklava' },
     etherscan: { name: 'Celo Explorer', url: 'https://explorer.celo.org/baklava' },
   },
+  multicall: {
+    address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+    blockCreated: 13112599
+  },
   testnet: true,
 };
 

--- a/packages/rainbowkit-celo/package.json
+++ b/packages/rainbowkit-celo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@celo/rainbowkit-celo",
   "author": "cLabs",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Quickly Setup RainbowKit for Celo",
   "homepage": "https://rainbowkit-with-celo.vercel.app/",
   "repository": {


### PR DESCRIPTION
given that alfajores [has multicall contract deployed](https://github.com/mds1/multicall/commit/de31d90773536161f41cef5c11880923fdb3c94c)

and [celo has had for a while](https://explorer.celo.org/mainnet/address/0xcA11bde05977b3631167028862bE2a173976CA11/contracts)

it makes sense to expose that so that we can use the `useContractReads` hook