### PR TITLE
Fix celo mainnet multicall config

### DIFF
--- a/packages/rainbowkit-celo/chains/baklava.ts
+++ b/packages/rainbowkit-celo/chains/baklava.ts
@@ -18,10 +18,6 @@ const Baklava: Chain = {
     default: { name: 'Celo Explorer', url: 'https://explorer.celo.org/baklava' },
     etherscan: { name: 'Celo Explorer', url: 'https://explorer.celo.org/baklava' },
   },
-  multicall: {
-    address: '0xcA11bde05977b3631167028862bE2a173976CA11',
-    blockCreated: 13112599
-  },
   testnet: true,
 };
 

--- a/packages/rainbowkit-celo/chains/celo.ts
+++ b/packages/rainbowkit-celo/chains/celo.ts
@@ -18,6 +18,10 @@ const Celo: Chain = {
     default: { name: 'Celo Explorer', url: 'https://explorer.celo.org/mainnet' },
     etherscan: { name: 'CeloScan', url: 'https://celoscan.io' },
   },
+  multicall: {
+    address: '0xcA11bde05977b3631167028862bE2a173976CA11',
+    blockCreated: 13112599
+  },
   testnet: false,
 };
 


### PR DESCRIPTION
There was a slight mix up in https://github.com/celo-org/rainbowkit-celo/pull/14
The [mainnet](https://explorer.celo.org/mainnet/address/0xcA11bde05977b3631167028862bE2a173976CA11/transactions) config was set for [baklava](https://explorer.celo.org/baklava/address/0xcA11bde05977b3631167028862bE2a173976CA11/transactions) (which doesn't have it).