### PR TITLE
updating workflow to pull npm publish token from akeyless

### DIFF
--- a/.github/workflows/test-workflow.yaml
+++ b/.github/workflows/test-workflow.yaml
@@ -10,12 +10,12 @@ jobs:
       contents: read
       id-token: write
 
-    uses: celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@v1.10.3
+    uses: celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@v1.10.4
     with:
       node-version: 16
       package-dir: "packages/rainbowkit-celo"
     secrets:
       npm-token: ${{ secrets.NPM_TOKEN }}
-      #akeyless-api-gateway: https://api.gateway.akeyless.celo-networks-dev.org
-      #akeyless-github-access-id: p-kf9vjzruht6l
-      #akeyless-token-path: /static-secrets/apps-payments-circle
+      akeyless-api-gateway: https://api.gateway.akeyless.celo-networks-dev.org
+      akeyless-github-access-id: p-kf9vjzruht6l
+      akeyless-token-path: /static-secrets/apps-tooling-circle/npm-publish-token


### PR DESCRIPTION
This workflow update should pull the secret from akeyless instead of github secrets