### PR TITLE
Fix unable to open Valora on iOS

### DIFF
--- a/packages/rainbowkit-celo/wallets/valora.ts
+++ b/packages/rainbowkit-celo/wallets/valora.ts
@@ -52,7 +52,7 @@ export const Valora = ({
           return isAndroid()
             ? uri
             : // ideally this would use the WalletConnect registry, but this will do for now
-              `https://valoraapp.com/wc?uri=${encodeURIComponent(uri)}`;
+              `celo://walllet/wc?uri=${encodeURIComponent(uri)}`;
         },
       },
       qrCode: {

--- a/packages/rainbowkit-celo/wallets/valora.ts
+++ b/packages/rainbowkit-celo/wallets/valora.ts
@@ -52,7 +52,7 @@ export const Valora = ({
           return isAndroid()
             ? uri
             : // ideally this would use the WalletConnect registry, but this will do for now
-              `celo://walllet/wc?uri=${encodeURIComponent(uri)}`;
+              `celo://wallet/wc?uri=${encodeURIComponent(uri)}`;
         },
       },
       qrCode: {


### PR DESCRIPTION
This fixes the issue observed in https://github.com/celo-org/rainbowkit-celo/pull/47#issuecomment-1610325185

It's now using the direct deeplink for Valora.

@DanielSinclair put me in the right direction with this in https://github.com/rainbow-me/rainbowkit/issues/1336#issuecomment-1612016204

I'm still not entirely sure why universal links can't be used, but this is what [Omni](https://github.com/rainbow-me/rainbowkit/blob/88168e1eb13fa1de7bffaea5d4839823f214a36a/packages/rainbowkit/src/wallets/walletConnectors/omniWallet/omniWallet.ts#L58), [Argent](https://github.com/rainbow-me/rainbowkit/blob/88168e1eb13fa1de7bffaea5d4839823f214a36a/packages/rainbowkit/src/wallets/walletConnectors/argentWallet/argentWallet.ts#L61), [Trust Wallet](https://github.com/rainbow-me/rainbowkit/blob/88168e1eb13fa1de7bffaea5d4839823f214a36a/packages/rainbowkit/src/wallets/walletConnectors/trustWallet/trustWallet.ts#L107) and all the other wallets listed in RainbowKit are doing since the [v2 upgrade](https://github.com/rainbow-me/rainbowkit/commit/e2b1072040a260d1888bcd854ef1fd0abaff2327).

Confirmed it works locally.