### PR TITLE
updating npm publish workflow to use latest which uses our hosted git…

### DIFF
--- a/.github/workflows/test-workflow.yaml
+++ b/.github/workflows/test-workflow.yaml
@@ -10,7 +10,7 @@ jobs:
       contents: read
       id-token: write
 
-    uses: celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@v1.10.5
+    uses: celo-org/reusable-workflows/.github/workflows/npm-publish.yaml@v1.11.1
     with:
       node-version: 16
       package-dir: "packages/rainbowkit-celo"


### PR DESCRIPTION
…hub actions controlers

Switching to version of reusable workflow that uses our self hosted servers for github actions