### PR TITLE
updating rainbowkit celo to use restricted token on main and prerelea…

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           api-url: https://api.gateway.akeyless.celo-networks-dev.org
           access-id: p-kf9vjzruht6l
-          static-secrets: '{"/static-secrets/apps-tooling-circle/npm-publish-token":"NPM_TOKEN"}'
+          static-secrets: '{"/static-secrets/apps-tooling-circle/npm-rainbowkit-celo":"NPM_TOKEN"}'
       - name: Setup Node.js 18.x
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
…se branches

This should work with main and prerelease branches to use the token that is restricted to rainbowkit npm package