### PR TITLE
fixing key path

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           api-url: https://api.gateway.akeyless.celo-networks-dev.org
           access-id: p-kf9vjzruht6l
-          static-secrets: '{"/static-secrets/apps-tooling-circle/npm-rainbowkit-celo":"NPM_TOKEN"}'
+          static-secrets: '{"/static-secrets/NPM/npm-rainbowkit-celo":"NPM_TOKEN"}'
       - name: Setup Node.js 18.x
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
If you run a new workflow for rainbowkit and it fails, this PR will fix it.
I messed up the last one you merged (https://github.com/celo-org/rainbowkit-celo/pull/88) and this is the fix.