### PR TITLE
Fix `maxFeePerGas` bug in example app

### DIFF
--- a/apps/example/pages/fee-currency.tsx
+++ b/apps/example/pages/fee-currency.tsx
@@ -146,7 +146,7 @@ function OverTheWire() {
       const tx: SendTransactionParameters<typeof celoAlfajores> = {
         account: client.data?.account!,
         feeCurrency: cUSDAddress.data,
-        maxFeePerGas: BigInt(700000),
+        maxFeePerGas: BigInt(5000000000),
         maxPriorityFeePerGas: BigInt(700000),
         value: BigInt(100000000000000000),
         to: '0x22579CA45eE22E2E16dDF72D955D6cf4c767B0eF',


### PR DESCRIPTION
### Description

Fixes `maxFeePerGas` bug in example app by increasing from 0.0007 gwei to 5 gwei (5e9 wei).

The bug was:

```sh
fee-currency-2d720879575e6073.js:1 EstimateGasExecutionError: The fee cap (`maxFeePerGas` = 0.0007 gwei) cannot be lower than the block base fee.

Estimate Gas Arguments:
  from:                  0xcf941f3e6a147Eb62c0f978CADCeD28e30F0D446
  to:                    0x22579CA45eE22E2E16dDF72D955D6cf4c767B0eF
  value:                 0.1 A-CELO
  maxFeePerGas:          0.0007 gwei
  maxPriorityFeePerGas:  0.0007 gwei

Details: err: max fee per gas less than block base fee: address 0xcf941f3e6a147Eb62c0f978CADCeD28e30F0D446, maxFeePerGas: 700000 baseFee: 3220896870 (supplied gas 5010499)
Version: viem@1.2.9
    at _app-934dd97cff7957aa.js:1:661115
    at b (_app-934dd97cff7957aa.js:1:661142)
    at async fee-currency-2d720879575e6073.js:1:3812
```

### Other changes

N/A

### Tested

Ran app locally with `yarn run dev`

### Related issues

N/A

### Backwards compatibility

Yes, should work as before.

### Documentation

N/A