### PR TITLE
extend base developer tooling renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>celo-org/.github:renovate-config"
+    "local>celo-org/.github:renovate-config",
+    "local>celo-org/developer-tooling:dt-renovate-base"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
_just another brick in the wall_

sets up repo to use base config from developer tooling repo. this configures renovate to be less aggressive. 