### PR TITLE
 #114 Remove cannoli from codebase

### DIFF
--- a/apps/example/pages/_app.tsx
+++ b/apps/example/pages/_app.tsx
@@ -5,10 +5,10 @@ import { RainbowKitProvider } from "@rainbow-me/rainbowkit";
 import { configureChains, createConfig, WagmiConfig } from "wagmi";
 import { jsonRpcProvider } from "wagmi/providers/jsonRpc";
 import celoGroups from "@celo/rainbowkit-celo/lists";
-import { Alfajores, Celo, Cannoli} from "@celo/rainbowkit-celo/chains";
+import { Alfajores, Celo } from "@celo/rainbowkit-celo/chains";
 
 const { chains, publicClient } = configureChains(
-  [Celo, Alfajores, Cannoli],
+  [Celo, Alfajores],
   [
     jsonRpcProvider({
       rpc: (chain) => ({ http: chain.rpcUrls.default.http[0] }),

--- a/apps/example/pages/index.tsx
+++ b/apps/example/pages/index.tsx
@@ -11,7 +11,7 @@ import { RainbowKitProvider } from "@rainbow-me/rainbowkit";
 import { configureChains, createConfig, WagmiConfig,  } from "wagmi";
 import { jsonRpcProvider } from "wagmi/providers/jsonRpc";
 import celoGroups from "@celo/rainbowkit-celo/lists"
-import { Alfajores, Celo, Cannoli } from "@celo/rainbowkit-celo/chains";
+import { Alfajores, Celo } from "@celo/rainbowkit-celo/chains";
 import "@rainbow-me/rainbowkit/styles.css";
 
 const projectId = "your-wallet-connnect-project-id" // get one at https://cloud.walletconnect.com/app
@@ -19,7 +19,7 @@ const projectId = "your-wallet-connnect-project-id" // get one at https://cloud.
 const connectors = celoGroups({chains, projectId, appName: typeof document === "object" && document.title || "Your App Name"})
 
 const { chains, publicClient } = configureChains(
-  [Alfajores, Celo, Cannoli],
+  [Alfajores, Celo],
   [jsonRpcProvider({ rpc: (chain) => ({ http: chain.rpcUrls.default.http[0] }) })]
 );
 const wagmiConfig = createConfig({

--- a/packages/rainbowkit-celo/chains/cannoli.ts
+++ b/packages/rainbowkit-celo/chains/cannoli.ts
@@ -1,9 +1,0 @@
-import { Chain } from "@rainbow-me/rainbowkit";
-import  {celoCannoli } from "viem/chains";
-const Cannoli: Chain = {
-  ...celoCannoli,
-  iconUrl: "https://rainbowkit-with-celo.vercel.app/icons/cannoli.svg",
-  iconBackground: "#FCF6F1",
-};
-
-export default Cannoli;

--- a/packages/rainbowkit-celo/chains/index.ts
+++ b/packages/rainbowkit-celo/chains/index.ts
@@ -1,4 +1,3 @@
 export { default as Alfajores } from "./alfajores.js";
-export { default as Cannoli } from "./cannoli.js";
 export { default as Celo } from "./celo.js";
 export { default as Baklava } from "./baklava.js";

--- a/packages/rainbowkit-celo/package.json
+++ b/packages/rainbowkit-celo/package.json
@@ -31,10 +31,6 @@
       "types": "./chains/baklava.d.ts",
       "import": "./chains/baklava.js"
     },
-    "./chains/cannoli": {
-      "types": "./chains/cannoli.d.ts",
-      "import": "./chains/cannoli.js"
-    },
     "./lists": {
       "types": "./lists/index.d.ts",
       "import": "./lists/index.js"

--- a/packages/rainbowkit-celo/wallets/valora.ts
+++ b/packages/rainbowkit-celo/wallets/valora.ts
@@ -8,7 +8,6 @@ import {
   Alfajores,
   Baklava,
   Celo,
-  Cannoli,
 } from "@celo/rainbowkit-celo/chains";
 import { getWalletConnectUri } from "@celo/rainbowkit-celo/utils/getWalletConnectUri";
 
@@ -25,7 +24,7 @@ export interface ValoraOptions {
 }
 
 export const Valora = ({
-  chains = [Alfajores, Baklava, Celo, Cannoli],
+  chains = [Alfajores, Baklava, Celo],
   projectId,
 }: ValoraOptions): Wallet => ({
   id: "valora",


### PR DESCRIPTION
### Description

Canolli network is no longer supported. This PR fixes error `Attempted import error: 'celoCannoli' is not exported from 'viem/chains'`

### Related issues

- Fixes #114 