### PR TITLE
Adds GitHub setup files

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-FORM.yml
@@ -1,0 +1,36 @@
+name: Bug report
+description: File a bug report
+labels: ["bug report"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Please ensure that the bug has not already been filed in the issue tracker.
+
+              Thanks for taking the time to report this bug!
+    - type: input
+      attributes:
+          label: What version of the package are you on?
+          description: |
+            For local installations, run: `npm list <package-name>`
+            For global installations, run: `npm list -g <package-name>`
+          placeholder: "Run command above and paste the output here"
+    - type: input
+      attributes:
+          label: What command or function is the bug in?
+          description: Leave empty if not relevant
+    - type: dropdown
+      attributes:
+          label: Operating System
+          description: What operating system are you on?
+          options:
+              - Windows
+              - macOS (Intel)
+              - macOS (Apple Silicon)
+              - Linux
+    - type: textarea
+      attributes:
+          label: Describe the bug
+          description: Please include relevant code snippets, terminal output, and screenshots if relevant.
+      validations:
+          required: true

--- a/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE-FORM.yml
@@ -1,0 +1,20 @@
+name: Feature request
+description: Suggest a feature
+labels: ["feature request"]
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Please ensure that the feature has not already been requested in the issue tracker.
+
+              Thanks for helping us improve Celo packages!
+    - type: textarea
+      attributes:
+          label: Describe the feature you would like
+          description: Please also describe what the feature is aiming to solve, if relevant.
+      validations:
+          required: true
+    - type: textarea
+      attributes:
+          label: Additional context
+          description: Add any other context to the feature (like screenshots, code snippets, resources)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Github Discussions
+    url: https://github.com/celo-org/rainbowkit-celo/discussions
+    about: Please ask and answer questions here.
+  - name: Docs
+    url: https://docs.celo.org/
+    about: Documentation on the Celo Platform

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing
+
+Thank you for your interest in improving `@celo/rainbowkit-celo`.
+
+If you want to contribute, but aren't sure where to start, you can create a
+[new discussion](https://github.com/celo-org/rainbowkit-celo/discussions).
+
+There are multiple opportunities to contribute. It doesn't matter if you are just
+getting started or are an expert. We appreciate your interest in contributing.
+
+> **IMPORTANT**
+> Please ask before starting work on any significant new features.
+>
+> It's never a fun experience to have your pull request declined after investing time and effort
+> into a new feature. To avoid this from happening, we invite contributors to create a
+> [new discussion](https://github.com/celo-org/rainbowkit-celo/discussions) to discuss API changes or
+> significant new ideas.
+
+## Basic guide
+
+This guide is intended to help you get started with contributing. By following these steps,
+you will understand the development process and workflow.
+
+### Cloning the repository
+
+To start contributing to the project, clone it to your local machine using git:
+
+```sh
+$ git clone git@github.com:celo-org/rainbowkit-celo.git
+```
+
+Navigate to the project's root directory:
+
+```sh
+$ cd rainbowkit-celo
+```
+
+### Installing Node.js
+
+We use [Node.js](https://nodejs.org/en/) to run the project locally.
+You need to install the **Node.js version** specified in [package.json > engines](./package.json). 
+
+### Installing dependencies
+
+Once in the project's root directory, run the following command to install the project's 
+dependencies:
+
+```sh
+$ yarn install
+```
+
+After installing the dependencies, the project is ready to be run. 
+
+### Navigating the repository
+
+The project is structured into a package (in [`packages/rainbowkit-celo/`](./packages/rainbowkit-celo/)) 
+and an example app (in [`apps/example`](./apps/example)).
+
+### Running packages
+
+Once you navigated to the project directory you want to run, inspect the `package.json` file
+and look for the `scripts` section. It contains the list of available scripts that can be run.
+
+### Versioning
+
+When adding new features or fixing bugs in `@celo/rainbowkit-celo`, we'll need to bump the package versions. 
+We use [Changesets](https://github.com/changesets/changesets) to do this.
+
+> **INFO**
+> Only changes to the codebase that affect the public API or existing behavior (e.g. bugs) 
+> need changesets.
+
+Each changeset defines which package(s) should be published and whether the change should be a 
+major/minor/patch release, as well as providing release notes that will be added to the changelog 
+upon release.
+
+To create a new changeset, run:
+
+```sh
+$ yarn run changeset
+```
+
+This will run the Changesets CLI, prompting you for details about the change. 
+You’ll be able to edit the file after it’s created — don’t worry about getting everything perfect 
+up front.
+
+Even though you can technically use any markdown formatting you like, headings should be avoided 
+since each changeset will ultimately be nested within a bullet list. Instead, bold text should be 
+used as section headings.
+
+If your PR is making changes to an area that already has a changeset (e.g. there’s an existing 
+changeset covering theme API changes but you’re making further changes to the same API), you 
+should update the existing changeset in your PR rather than creating a new one.
+
+### Running the test suite 
+
+Unfortunately, we don't have a consistent test suite for this package.
+
+When you open a Pull Request, the GitHub CI will run any available test suites for you, but 
+you can also add and run tests locally.
+
+> **INFO**
+> Some tests are run automatically when you open a Pull Request, while others are run when a 
+> maintainer approves the Pull Request. This is for security reasons, as some tests require access 
+> to secrets.
+
+### Open a Pull Request
+
+✅ Now you're ready to contribute to `@celo/rainbowkit-celo`!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ you will understand the development process and workflow.
 To start contributing to the project, clone it to your local machine using git:
 
 ```sh
-$ git clone git@github.com:celo-org/rainbowkit-celo.git
+$ git clone https://github.com/celo-org/rainbowkit-celo.git
 ```
 
 Navigate to the project's root directory:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/rainbowkit-celo/package.json
+++ b/packages/rainbowkit-celo/package.json
@@ -54,7 +54,7 @@
   },
   "type": "module",
   "sideEffects": false,
-  "license": "MIT",
+  "license": "Apache-2.0",
   "keywords": [
     "celo",
     "dapp",


### PR DESCRIPTION
### Description

- Changes LICENSE from MIT to Apache 2.0. This is consistent with the other packages in [`celo-org/developer-tooling`](https://github.com/celo-org/developer-tooling)
- Adds bug report and feature request template
- Adds `CONTRIBUTING.md` file

### Other changes

None

### Tested

Only docs changes.

### Related issues

- Fixes #110 

### Backwards compatibility

Yes

### Documentation

Yes