### PR TITLE
add a manual trigger for testing authless

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,14 @@ on:
     branches:
       - main
       - 'prerelease/*'
-
+  workflow_dispatch:
+    inputs:
+      checkAuth:
+          description: 'For checking that auth works'
+          required: true
+          type: choice
+          options: 
+            - "yes"
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -28,7 +35,12 @@ jobs:
         with:
           api-url: https://api.gateway.akeyless.celo-networks-dev.org
           access-id: p-kf9vjzruht6l
-          static-secrets: '{"/static-secrets/NPM/npm-rainbowkit-celo":"NPM_TOKEN"}'
+          static-secrets: '{"/static-secrets/NPM/npm-publish-token":"NPM_TOKEN"}'
+      - name: Confirm Tokens 
+        if: ${{ inputs.checkAuth }} === "true"
+        run: |
+            echo "Success npm tokens recieved"  
+            exit 1           
       - name: Setup Node.js 18.x
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
           access-id: p-kf9vjzruht6l
           static-secrets: '{"/static-secrets/NPM/npm-publish-token":"NPM_TOKEN"}'
       - name: Confirm Tokens 
-        if: ${{ inputs.checkAuth }} === "true"
+        if: ${{ inputs.checkAuth }} === "yes"
         run: |
             echo "Success npm tokens recieved"  
             exit 1           

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
       - 'prerelease/*'
   workflow_dispatch:
     inputs:
-      checkAuth:
+      checkAuthOnly:
           description: 'For checking that auth works'
           required: true
           type: choice
@@ -36,11 +36,6 @@ jobs:
           api-url: https://api.gateway.akeyless.celo-networks-dev.org
           access-id: p-kf9vjzruht6l
           static-secrets: '{"/static-secrets/NPM/npm-publish-token":"NPM_TOKEN"}'
-      - name: Confirm Tokens 
-        if: ${{ inputs.checkAuth }} === "yes"
-        run: |
-            echo "Success npm tokens recieved"  
-            exit 1           
       - name: Setup Node.js 18.x
         uses: actions/setup-node@v4
         with:
@@ -54,6 +49,7 @@ jobs:
         shell: bash
         run: yarn
       - name: Create Release Pull Request or Publish to npm
+        if:  ${{ inputs.checkAuthOnly }} != "yes"
         id: changesets
         uses: changesets/action@v1
         env:


### PR DESCRIPTION
### Description

When security updates the auth they need a way to test without actually publishing.

If the token is successfully fetched then skipp running changeset action.

downside If token is received but not valid then success here would still mean failure in publishing