### PR TITLE
Correcting the secret that is accessed by the test auth workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           api-url: https://api.gateway.akeyless.celo-networks-dev.org
           access-id: p-kf9vjzruht6l
-          static-secrets: '{"/static-secrets/NPM/npm-publish-token":"NPM_TOKEN"}'
+          static-secrets: '{"/static-secrets/NPM/npm-rainbowkit-celo":"NPM_TOKEN"}'
       - name: Setup Node.js 18.x
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
to npm-rainbowkit-celo (the correct key for this repo)

### Description

Correcting the secret path for the one that this repo uses and is restricted to rainbowkit.

