### PR TITLE
updating the npm token used to be the one for all packages instead of…

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           api-url: https://api.gateway.akeyless.celo-networks-dev.org
           access-id: p-kf9vjzruht6l
-          static-secrets: '{"/static-secrets/NPM/npm-rainbowkit-celo":"NPM_TOKEN"}'
+          static-secrets: '{"/static-secrets/NPM/npm-publish-token":"NPM_TOKEN"}'
       - name: Setup Node.js 18.x
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION


Changing the akeyless token used by the CI/CD to use the token all other ci uses instead of a separate limited one for rainbowkit.